### PR TITLE
add interface to get witness signature from wallet

### DIFF
--- a/internal/wallet/sign.go
+++ b/internal/wallet/sign.go
@@ -1,0 +1,27 @@
+package wallet
+
+import (
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/dgarage/dlc/internal/script"
+)
+
+// WitnessSignature returns witness signature
+// by getting privkey from a given pubkey
+func (w *wallet) WitnessSignature(
+	tx *wire.MsgTx, idx int, amt int64, sc []byte, pub *btcec.PublicKey,
+) (sign []byte, err error) {
+	priv, err := w.privkeyFromPubkey(pub)
+	if err != nil {
+		return
+	}
+
+	return script.WitnessSignature(tx, idx, amt, sc, priv)
+}
+
+// privkeyFromPubkey retrieves a privkey for a given pubkey
+func (w *wallet) privkeyFromPubkey(
+	pub *btcec.PublicKey) (priv *btcec.PrivateKey, err error) {
+	// TODO implement this function
+	return
+}

--- a/internal/wallet/wallet.go
+++ b/internal/wallet/wallet.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
@@ -21,6 +22,11 @@ type Wallet interface {
 	NewPubkey() (*btcec.PublicKey, error)
 
 	NewWitnessPubkeyScript() (pkScript []byte, err error)
+
+	// WitnessSignature returns witness signature for a given txin and pubkey
+	WitnessSignature(
+		tx *wire.MsgTx, idx int, amt int64, script []byte, pub *btcec.PublicKey,
+	) (sign []byte, err error)
 
 	ListUnspent() (utxos []Utxo, err error)
 


### PR DESCRIPTION
Wallet needs to provide an interface that gives witness signature for given txin using a privkey managed by wallet internally.