### PR TITLE
implement wallet.WitnessSignature

### DIFF
--- a/internal/test/tx.go
+++ b/internal/test/tx.go
@@ -9,11 +9,30 @@ import (
 // TxVersion is a default tx version
 const TxVersion = int32(2)
 
-// SourceTx creates a transaction that has a dummy txin.
-func SourceTx() *wire.MsgTx {
+// NewSourceTx creates a transaction that has a dummy txin.
+func NewSourceTx() *wire.MsgTx {
 	tx := wire.NewMsgTx(TxVersion)
 	prevOut := wire.NewOutPoint(&chainhash.Hash{}, ^uint32(0))
 	txIn := wire.NewTxIn(prevOut, []byte{txscript.OP_0, txscript.OP_0}, nil)
 	tx.AddTxIn(txIn)
 	return tx
+}
+
+// NewRedeemTx creates a redeem tx using a given sourct tx
+func NewRedeemTx(sourceTx *wire.MsgTx) *wire.MsgTx {
+	txHash := sourceTx.TxHash()
+	outPt := wire.NewOutPoint(&txHash, 0)
+	tx := wire.NewMsgTx(TxVersion)
+	tx.AddTxIn(wire.NewTxIn(outPt, nil, nil))
+	return tx
+}
+
+// ExecuteScript runs given script
+func ExecuteScript(pkScript []byte, tx *wire.MsgTx, amt int64) error {
+	flags := txscript.StandardVerifyFlags
+	vm, err := txscript.NewEngine(pkScript, tx, 0, flags, nil, nil, amt)
+	if err != nil {
+		return err
+	}
+	return vm.Execute()
 }

--- a/internal/wallet/address.go
+++ b/internal/wallet/address.go
@@ -1,10 +1,11 @@
 package wallet
 
 import (
+	"errors"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcwallet/waddrmgr"
 	"github.com/btcsuite/btcwallet/walletdb"
-	"github.com/dgarage/dlc/internal/script"
 )
 
 func (w *wallet) NewPubkey() (pub *btcec.PublicKey, err error) {
@@ -14,15 +15,6 @@ func (w *wallet) NewPubkey() (pub *btcec.PublicKey, err error) {
 	}
 	pub = (mAddr.(waddrmgr.ManagedPubKeyAddress)).PubKey()
 	return pub, err
-}
-
-func (w *wallet) NewWitnessPubkeyScript() (pkScript []byte, err error) {
-	var pub *btcec.PublicKey
-	pub, err = w.NewPubkey()
-	if err != nil {
-		return
-	}
-	return script.P2WPKHpkScript(pub)
 }
 
 // NewAddress returns a new ManagedAddress
@@ -46,4 +38,29 @@ func (w *wallet) newAddress() (waddrmgr.ManagedAddress, error) {
 	}
 
 	return addrs[0], nil
+}
+
+func (w *wallet) managedPubKeyAddressFromPubkey(
+	pub *btcec.PublicKey,
+) (rmpaddr waddrmgr.ManagedPubKeyAddress, err error) {
+	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		ns := tx.ReadBucket(waddrmgrNamespaceKey)
+		if ns == nil {
+			return errors.New("missing address manager namespace")
+		}
+		e := w.manager.ForEachActiveAccountAddress(ns, w.account,
+			func(maddr waddrmgr.ManagedAddress) error {
+				mpaddr, ok := maddr.(waddrmgr.ManagedPubKeyAddress)
+				if !ok {
+					return nil
+				}
+				if !mpaddr.PubKey().IsEqual(pub) {
+					return nil
+				}
+				rmpaddr = mpaddr
+				return nil
+			})
+		return e
+	})
+	return rmpaddr, err
 }

--- a/internal/wallet/address.go
+++ b/internal/wallet/address.go
@@ -62,5 +62,9 @@ func (w *wallet) managedPubKeyAddressFromPubkey(
 			})
 		return e
 	})
+	if rmpaddr == nil {
+		msg := "No pubkey address is found associated with the given pubkey"
+		return nil, errors.New(msg)
+	}
 	return rmpaddr, err
 }

--- a/internal/wallet/address_test.go
+++ b/internal/wallet/address_test.go
@@ -15,13 +15,3 @@ func TestNewPubkey(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, pub)
 }
-
-func TestNewWitnessPubkeyScript(t *testing.T) {
-	wallet, tearDownFunc := setupWallet(t)
-	defer tearDownFunc()
-
-	pkScript, err := wallet.NewWitnessPubkeyScript()
-
-	assert.Nil(t, err)
-	assert.NotEmpty(t, pkScript)
-}

--- a/internal/wallet/sign.go
+++ b/internal/wallet/sign.go
@@ -3,25 +3,24 @@ package wallet
 import (
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
 	"github.com/dgarage/dlc/internal/script"
 )
 
 // WitnessSignature returns witness signature
-// by getting privkey from a given pubkey
+// by creating a new keyset and signing tx with its privkey
 func (w *wallet) WitnessSignature(
-	tx *wire.MsgTx, idx int, amt int64, sc []byte, pub *btcec.PublicKey,
-) (sign []byte, err error) {
-	priv, err := w.privkeyFromPubkey(pub)
+	tx *wire.MsgTx, idx int, amt btcutil.Amount, sc []byte, pub *btcec.PublicKey,
+) ([]byte, error) {
+	mpaddr, err := w.managedPubKeyAddressFromPubkey(pub)
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	return script.WitnessSignature(tx, idx, amt, sc, priv)
-}
-
-// privkeyFromPubkey retrieves a privkey for a given pubkey
-func (w *wallet) privkeyFromPubkey(
-	pub *btcec.PublicKey) (priv *btcec.PrivateKey, err error) {
-	// TODO implement this function
-	return
+	priv, err := mpaddr.PrivKey()
+	if err != nil {
+		return nil, err
+	}
+	sign, err := script.WitnessSignature(tx, idx, int64(amt), sc, priv)
+	return sign, err
 }

--- a/internal/wallet/sign_test.go
+++ b/internal/wallet/sign_test.go
@@ -1,0 +1,46 @@
+package wallet
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/dgarage/dlc/internal/script"
+	"github.com/dgarage/dlc/internal/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWitnessSignature(t *testing.T) {
+	assert := assert.New(t)
+
+	w, tearDownFunc := setupWallet(t)
+	defer tearDownFunc()
+
+	// pubkey and pk script
+	pub, _ := w.NewPubkey()
+	pkScript, _ := script.P2WPKHpkScript(pub)
+
+	// prepare source tx
+	amt := btcutil.Amount(10000)
+	sourceTx := test.NewSourceTx()
+	sourceTx.AddTxOut(wire.NewTxOut(int64(amt), pkScript))
+
+	redeemTx := test.NewRedeemTx(sourceTx)
+
+	// should fail if it's not unlocked
+	_, err := w.WitnessSignature(redeemTx, 0, amt, pkScript, pub)
+	assert.NotNil(err)
+
+	// unlock for private key access
+	w.Unlock(testPrivPass)
+
+	sign, err := w.WitnessSignature(redeemTx, 0, amt, pkScript, pub)
+	assert.Nil(err)
+
+	wt := wire.TxWitness{sign, pub.SerializeCompressed()}
+	redeemTx.TxIn[0].Witness = wt
+
+	// execute script
+	err = test.ExecuteScript(pkScript, redeemTx, int64(amt))
+	assert.Nil(err)
+}

--- a/internal/wallet/wallet.go
+++ b/internal/wallet/wallet.go
@@ -23,7 +23,11 @@ type Wallet interface {
 
 	// WitnessSignature returns witness signature for a given txin and pubkey
 	WitnessSignature(
-		tx *wire.MsgTx, idx int, amt btcutil.Amount, script []byte, pub *btcec.PublicKey
+		tx *wire.MsgTx,
+		idx int,
+		amt btcutil.Amount,
+		script []byte,
+		pub *btcec.PublicKey,
 	) (sign []byte, err error)
 
 	ListUnspent() (utxos []Utxo, err error)

--- a/internal/wallet/wallet.go
+++ b/internal/wallet/wallet.go
@@ -21,11 +21,9 @@ import (
 type Wallet interface {
 	NewPubkey() (*btcec.PublicKey, error)
 
-	NewWitnessPubkeyScript() (pkScript []byte, err error)
-
 	// WitnessSignature returns witness signature for a given txin and pubkey
 	WitnessSignature(
-		tx *wire.MsgTx, idx int, amt int64, script []byte, pub *btcec.PublicKey,
+		tx *wire.MsgTx, idx int, amt btcutil.Amount, script []byte, pub *btcec.PublicKey
 	) (sign []byte, err error)
 
 	ListUnspent() (utxos []Utxo, err error)
@@ -35,6 +33,9 @@ type Wallet interface {
 	SelectUnspent(
 		amt, feePerTxIn, feePerTxOut btcutil.Amount,
 	) (utxos []Utxo, change btcutil.Amount, err error)
+
+	// Unlock unlocks address manager
+	Unlock(privPass []byte) error
 
 	Close() error
 }
@@ -58,6 +59,9 @@ type wallet struct {
 	txStore *wtxmgr.Store
 	account uint32
 }
+
+// wallet should satisfy Wallet interface
+var _ Wallet = (*wallet)(nil)
 
 // CreateWallet returns a new Wallet, also creates db where wallet resides
 // TODO: separate db creation and Manager creation
@@ -238,6 +242,14 @@ func open(
 	}
 
 	return w, nil
+}
+
+// Unlock unlocks address manager with a given private pass phrase
+func (w *wallet) Unlock(privPass []byte) error {
+	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
+		ns := tx.ReadWriteBucket(waddrmgrNamespaceKey)
+		return w.manager.Unlock(ns, privPass)
+	})
 }
 
 // Close closes managers


### PR DESCRIPTION
This PR implements `wallet.WitnessSignature`.  It requires a user providing passphrase to unlock for private key access. This looks natural to me as signning process must be securely done.