### PR TITLE
contract execution script

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -6,5 +6,6 @@
     ".*/test_util.go"
   ],
   "EnableAll": true,
+  "Disable": ["unparam"],
   "LineLength": 120
 }

--- a/internal/dlc/deal.go
+++ b/internal/dlc/deal.go
@@ -8,7 +8,7 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
-// Deal contains destributing amounts and committed messages and signs of messages
+// Deal contains information about the distributed amounts, commitment messages, and signatures of fixed messages
 type Deal struct {
 	amts          map[Contractor]btcutil.Amount
 	msgs          [][]byte

--- a/internal/dlc/deal.go
+++ b/internal/dlc/deal.go
@@ -1,0 +1,72 @@
+package dlc
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcutil"
+)
+
+// Deal contains destributing amounts and commited messages and signs of messages
+type Deal struct {
+	amts          map[Contractor]btcutil.Amount
+	msgs          [][]byte
+	msgCommitment *btcec.PublicKey
+	msgSign       []byte // oracle's message sign
+	cpSign        []byte // conterparty's sign
+}
+
+// NewDeal creates a new deal
+func NewDeal(amt1, amt2 btcutil.Amount, msgs [][]byte) *Deal {
+	amts := make(map[Contractor]btcutil.Amount)
+	amts[FirstParty] = amt1
+	amts[SecondParty] = amt2
+	return &Deal{
+		amts: amts,
+		msgs: msgs,
+	}
+}
+
+// AddDeal adds a deal to DLC
+func (b *Builder) AddDeal(deal *Deal) int {
+	b.dlc.deals = append(b.dlc.deals, deal)
+	return len(b.dlc.deals) - 1
+}
+
+// Deal gets a deal by id
+func (d *DLC) Deal(idx int) (*Deal, error) {
+	if len(d.deals) < idx+1 {
+		errmsg := fmt.Sprintf("Invalid deal id. id: %d", idx)
+		return nil, errors.New(errmsg)
+	}
+
+	deal := d.deals[idx]
+	return deal, nil
+}
+
+// SetMsgCommitmentToDeal sets a message commitment received from oracle
+func (b *Builder) SetMsgCommitmentToDeal(
+	idx int, mc *btcec.PublicKey) error {
+
+	d, err := b.dlc.Deal(idx)
+	if err != nil {
+		return err
+	}
+
+	d.msgCommitment = mc
+	return nil
+}
+
+// SetContextExecutionSign sets a sign received from the counterparty
+func (b *Builder) SetContextExecutionSign(
+	idx int, sign []byte) error {
+
+	d, err := b.dlc.Deal(idx)
+	if err != nil {
+		return err
+	}
+
+	d.cpSign = sign
+	return nil
+}

--- a/internal/dlc/deal.go
+++ b/internal/dlc/deal.go
@@ -14,7 +14,7 @@ type Deal struct {
 	msgs          [][]byte
 	msgCommitment *btcec.PublicKey
 	msgSign       []byte // oracle's message sign
-	cpSign        []byte // conterparty's sign
+	cpSign        []byte // counterparty's sign
 }
 
 // NewDeal creates a new deal

--- a/internal/dlc/deal.go
+++ b/internal/dlc/deal.go
@@ -13,8 +13,8 @@ type Deal struct {
 	amts          map[Contractor]btcutil.Amount
 	msgs          [][]byte
 	msgCommitment *btcec.PublicKey
-	// msgSign       []byte // oracle's message sign
-	cpSign []byte // conterparty's sign
+	msgSign       []byte // oracle's message sign
+	cpSign        []byte // conterparty's sign
 }
 
 // NewDeal creates a new deal
@@ -45,6 +45,16 @@ func (d *DLC) Deal(idx int) (*Deal, error) {
 	return deal, nil
 }
 
+// FixedDeal returns a fixed deal
+func (d *DLC) FixedDeal() (*Deal, error) {
+	for _, deal := range d.deals {
+		if deal.msgSign != nil {
+			return deal, nil
+		}
+	}
+	return nil, errors.New("no fixed deal found")
+}
+
 // SetMsgCommitmentToDeal sets a message commitment received from oracle
 func (b *Builder) SetMsgCommitmentToDeal(
 	idx int, mc *btcec.PublicKey) error {
@@ -55,5 +65,18 @@ func (b *Builder) SetMsgCommitmentToDeal(
 	}
 
 	d.msgCommitment = mc
+	return nil
+}
+
+// FixDeal fixes a deal by setting the signature provided by oracle
+func (b *Builder) FixDeal(idx int, sign []byte) error {
+	d, err := b.dlc.Deal(idx)
+	if err != nil {
+		return err
+	}
+
+	// TODO: verify the given sign
+
+	d.msgSign = sign
 	return nil
 }

--- a/internal/dlc/deal.go
+++ b/internal/dlc/deal.go
@@ -57,16 +57,3 @@ func (b *Builder) SetMsgCommitmentToDeal(
 	d.msgCommitment = mc
 	return nil
 }
-
-// SetContextExecutionSign sets a sign received from the counterparty
-func (b *Builder) SetContextExecutionSign(
-	idx int, sign []byte) error {
-
-	d, err := b.dlc.Deal(idx)
-	if err != nil {
-		return err
-	}
-
-	d.cpSign = sign
-	return nil
-}

--- a/internal/dlc/deal.go
+++ b/internal/dlc/deal.go
@@ -8,13 +8,13 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
-// Deal contains destributing amounts and commited messages and signs of messages
+// Deal contains destributing amounts and committed messages and signs of messages
 type Deal struct {
 	amts          map[Contractor]btcutil.Amount
 	msgs          [][]byte
 	msgCommitment *btcec.PublicKey
-	msgSign       []byte // oracle's message sign
-	cpSign        []byte // conterparty's sign
+	// msgSign       []byte // oracle's message sign
+	cpSign []byte // conterparty's sign
 }
 
 // NewDeal creates a new deal

--- a/internal/dlc/dlc.go
+++ b/internal/dlc/dlc.go
@@ -16,6 +16,7 @@ import (
 // including FundTx, SettlementTx, RefundTx
 type DLC struct {
 	conds Conditions
+	deals []*Deal // TODO: move to Conditions
 
 	// requirements to execute DLC
 	pubs        map[Contractor]*btcec.PublicKey
@@ -93,7 +94,7 @@ const (
 )
 
 // counterparty returns the counterparty
-func (d *DLC) counterparty(p Contractor) (cp Contractor) {
+func counterparty(p Contractor) (cp Contractor) {
 	switch p {
 	case FirstParty:
 		cp = SecondParty
@@ -137,7 +138,7 @@ func (b *Builder) PreparePubkey() error {
 
 // CopyReqsFromCounterparty copies requirements from counterparty
 func (b *Builder) CopyReqsFromCounterparty(d *DLC) {
-	p := b.dlc.counterparty(b.party)
+	p := counterparty(b.party)
 
 	// pubkey
 	b.dlc.pubs[p] = d.pubs[p]

--- a/internal/dlc/dlc.go
+++ b/internal/dlc/dlc.go
@@ -151,7 +151,7 @@ func (b *Builder) CopyReqsFromCounterparty(d *DLC) {
 
 // AcceptCounterpartySign verifies couterparty's given sign is valid and then
 func (b *Builder) AcceptCounterpartySign(sign []byte) error {
-	p := b.dlc.counterparty(b.party)
+	p := counterparty(b.party)
 
 	err := b.dlc.VerifyRefundTx(sign, b.dlc.pubs[p])
 	if err != nil {

--- a/internal/dlc/dlc.go
+++ b/internal/dlc/dlc.go
@@ -2,7 +2,6 @@ package dlc
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/wire"
@@ -147,18 +146,4 @@ func (b *Builder) CopyReqsFromCounterparty(d *DLC) {
 	fundReqs := d.fundTxReqs
 	b.dlc.fundTxReqs.txIns[p] = fundReqs.txIns[p]
 	b.dlc.fundTxReqs.txOut[p] = fundReqs.txOut[p]
-}
-
-// AcceptCounterpartySign verifies couterparty's given sign is valid and then
-func (b *Builder) AcceptCounterpartySign(sign []byte) error {
-	p := counterparty(b.party)
-
-	err := b.dlc.VerifyRefundTx(sign, b.dlc.pubs[p])
-	if err != nil {
-		return fmt.Errorf("counterparty's signature didn't pass verification, had error: %v", err)
-	}
-
-	// sign passed verification, accept it
-	b.dlc.refundSigns[p] = sign
-	return nil
 }

--- a/internal/dlc/errors.go
+++ b/internal/dlc/errors.go
@@ -1,0 +1,13 @@
+package dlc
+
+import "errors"
+
+// CETTakeNothingError is an error for invalid CET
+// Doesn't make sense to create a CTE that takes nothing
+type CETTakeNothingError struct {
+	error
+}
+
+func newCETTakeNothingError(msg string) *CETTakeNothingError {
+	return &CETTakeNothingError{error: errors.New(msg)}
+}

--- a/internal/dlc/execution.go
+++ b/internal/dlc/execution.go
@@ -30,6 +30,11 @@ func (d *DLC) ContractExecutionTx(
 	amt1 := deal.amts[party]
 	amt2 := deal.amts[cparty]
 
+	if amt1 == 0 {
+		errmsg := "Amount for a multisig script address shouldn't be zero"
+		return nil, newCETTakeNothingError(errmsg)
+	}
+
 	// txout1: contract execution script
 	pub1 := d.pubs[party]
 	if pub1 == nil {

--- a/internal/dlc/execution.go
+++ b/internal/dlc/execution.go
@@ -1,0 +1,124 @@
+package dlc
+
+import (
+	"errors"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/dgarage/dlc/internal/script"
+)
+
+// ContractExecutionTx constracts a contract execution tx (CET) using pubkeys and given condition.
+// Both parties have different transactions signed by the other side.
+//
+// input:
+//   [0]:fund transaction output[0]
+// output:
+//   [0]:settlement script
+//   [1]:p2wpkh (option)
+func (d *DLC) ContractExecutionTx(
+	party Contractor, deal *Deal) (*wire.MsgTx, error) {
+	cparty := counterparty(party)
+
+	tx, err := d.newRedeemTx()
+	if err != nil {
+		return nil, err
+	}
+
+	// out values
+	amt1 := deal.amts[party]
+	amt2 := deal.amts[cparty]
+
+	// txout1: contract execution script
+	pub1 := d.pubs[party]
+	if pub1 == nil {
+		return nil, errors.New("missing pubkey")
+	}
+	pub2 := d.pubs[cparty]
+	if pub2 == nil {
+		return nil, errors.New("missing pubkey")
+	}
+	if deal.msgCommitment == nil {
+		return nil, errors.New("missing oracle's message commitment")
+	}
+	sc, err := script.ContractExecutionScript(pub1, pub2, deal.msgCommitment)
+	if err != nil {
+		return nil, err
+	}
+	pkScript, err := script.P2WSHpkScript(sc)
+	if err != nil {
+		return nil, err
+	}
+
+	txout1 := wire.NewTxOut(int64(amt1), pkScript)
+	tx.AddTxOut(txout1)
+
+	// txout2: counterparty's p2wpkh
+	if amt1 > 0 {
+		txout2, err := d.ClosingTxOut(cparty, amt2)
+		if err != nil {
+			return nil, err
+		}
+		tx.AddTxOut(txout2)
+	}
+	return tx, nil
+}
+
+// SignContractExecutionTx signs a contract exection tx for a given party
+func (b *Builder) SignContractExecutionTx(
+	party Contractor, idx int) ([]byte, error) {
+
+	cparty := counterparty(b.party)
+
+	deal, err := b.dlc.Deal(idx)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := b.dlc.ContractExecutionTx(cparty, deal)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: verify contract execution tx
+
+	return b.witsigForFundTxIn(tx)
+}
+
+// SignedContractExecutionTx returns a contract execution tx signed by both parties
+func (b *Builder) SignedContractExecutionTx(idx int) (*wire.MsgTx, error) {
+	deal, err := b.dlc.Deal(idx)
+	if err != nil {
+		return nil, err
+	}
+
+	tx, err := b.dlc.ContractExecutionTx(b.party, deal)
+	if err != nil {
+		return nil, err
+	}
+
+	sign, err := b.witsigForFundTxIn(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	if deal.cpSign == nil {
+		return nil, errors.New("missing counterparty's sign")
+	}
+
+	var sign1, sign2 []byte
+	switch b.party {
+	case FirstParty:
+		sign1, sign2 = sign, deal.cpSign
+	case SecondParty:
+		sign1, sign2 = deal.cpSign, sign
+	}
+
+	wit, err := b.dlc.witnessForFundScript(sign1, sign2)
+	if err != nil {
+		return nil, err
+	}
+
+	tx.TxIn[fundTxInAt].Witness = wit
+
+	return tx, nil
+}

--- a/internal/dlc/execution.go
+++ b/internal/dlc/execution.go
@@ -12,9 +12,9 @@ import (
 // ContractExecutionTx constructs a contract execution tx (CET) using pubkeys and given condition.
 // Both parties have different transactions signed by the other side.
 //
-// input:
+// txins:
 //   [0]:fund transaction output[0]
-// output:
+// txouts:
 //   [0]:settlement script
 //   [1]:p2wpkh (option)
 func (d *DLC) ContractExecutionTx(

--- a/internal/dlc/execution.go
+++ b/internal/dlc/execution.go
@@ -61,7 +61,7 @@ func (d *DLC) ContractExecutionTx(
 	tx.AddTxOut(txout1)
 
 	// txout2: counterparty's p2wpkh
-	if amt1 > 0 {
+	if amt2 > 0 {
 		txout2, err := d.ClosingTxOut(cparty, amt2)
 		if err != nil {
 			return nil, err
@@ -79,8 +79,6 @@ func (b *Builder) SignContractExecutionTx(idx int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: verify contract execution tx
 
 	return b.witsigForFundTxIn(tx)
 }

--- a/internal/dlc/execution.go
+++ b/internal/dlc/execution.go
@@ -9,7 +9,7 @@ import (
 	"github.com/dgarage/dlc/internal/script"
 )
 
-// ContractExecutionTx constracts a contract execution tx (CET) using pubkeys and given condition.
+// ContractExecutionTx constructs a contract execution tx (CET) using pubkeys and given condition.
 // Both parties have different transactions signed by the other side.
 //
 // input:
@@ -71,7 +71,7 @@ func (d *DLC) ContractExecutionTx(
 	return tx, nil
 }
 
-// SignContractExecutionTx signs a contract exection tx for a given party
+// SignContractExecutionTx signs a contract execution tx for a given party
 func (b *Builder) SignContractExecutionTx(idx int) ([]byte, error) {
 	cparty := counterparty(b.party)
 

--- a/internal/dlc/execution.go
+++ b/internal/dlc/execution.go
@@ -83,8 +83,8 @@ func (b *Builder) SignContractExecutionTx(idx int) ([]byte, error) {
 	return b.witsigForFundTxIn(tx)
 }
 
-// SetContextExecutionSign sets a sign received from the counterparty
-func (b *Builder) SetContextExecutionSign(
+// AcceptCETxSign sets a sign received from the counterparty
+func (b *Builder) AcceptCETxSign(
 	idx int, sign []byte) error {
 
 	// verify

--- a/internal/dlc/execution_test.go
+++ b/internal/dlc/execution_test.go
@@ -60,9 +60,17 @@ func TestCotractExecutionTx(t *testing.T) {
 	assert.Nil(err)
 	tx2, err := b2.SignedContractExecutionTx(dID)
 	assert.Nil(err)
-	assert.NotEqual(tx1, tx2)
 
-	// run script
+	// each party has a tx that has the same txin but has different txouts
+	assert.Len(tx1.TxOut, 2)
+	assert.Len(tx2.TxOut, 2)
+	assert.Equal(
+		tx1.TxIn[fundTxInAt].PreviousOutPoint,
+		tx2.TxIn[fundTxInAt].PreviousOutPoint)
+	assert.Equal(tx1.TxOut[0].Value, tx2.TxOut[1].Value)
+	assert.Equal(tx1.TxOut[1].Value, tx2.TxOut[0].Value)
+
+	// Both parties are able to send the CET
 	err = runFundScript(b1, tx1)
 	assert.Nil(err)
 	err = runFundScript(b2, tx2)

--- a/internal/dlc/execution_test.go
+++ b/internal/dlc/execution_test.go
@@ -96,17 +96,19 @@ func TestSignedContractExecutionTx(t *testing.T) {
 }
 
 func setupContractors() (b1, b2 *Builder) {
+	conds, _ := NewConditions(1, 1, 1, 1, 1)
+
 	// init first party
 	w1 := setupTestWallet()
-	b1 = NewBuilder(FirstParty, mockSelectUnspent(w1, 1, 1, nil))
-	b1.SetFundAmounts(1, 1)
+	w1 = mockSelectUnspent(w1, 1, 1, nil)
+	b1 = NewBuilder(FirstParty, w1, conds)
 	b1.PreparePubkey()
 	b1.PrepareFundTxIns()
 
 	// init second party
 	w2 := setupTestWallet()
-	b2 = NewBuilder(SecondParty, mockSelectUnspent(w2, 1, 1, nil))
-	b2.SetFundAmounts(1, 1)
+	w2 = mockSelectUnspent(w2, 1, 1, nil)
+	b2 = NewBuilder(SecondParty, w2, conds)
 	b2.PreparePubkey()
 	b2.PrepareFundTxIns()
 

--- a/internal/dlc/execution_test.go
+++ b/internal/dlc/execution_test.go
@@ -68,9 +68,9 @@ func TestSignedContractExecutionTx(t *testing.T) {
 	sign2, err := b2.SignContractExecutionTx(dID)
 	assert.Nil(err)
 
-	err = b1.SetContextExecutionSign(dID, sign2)
+	err = b1.AcceptCETxSign(dID, sign2)
 	assert.Nil(err)
-	err = b2.SetContextExecutionSign(dID, sign1)
+	err = b2.AcceptCETxSign(dID, sign1)
 	assert.Nil(err)
 
 	// no errors with the counterparty's sign

--- a/internal/dlc/execution_test.go
+++ b/internal/dlc/execution_test.go
@@ -16,7 +16,7 @@ func TestCotractExecutionTx(t *testing.T) {
 
 	// prepare a deal
 	var amt1, amt2 btcutil.Amount = 1, 1
-	msgs := [][]byte{[]byte{1}, []byte{1}}
+	msgs := [][]byte{{1}, {1}}
 	deal1 := NewDeal(amt1, amt2, msgs)
 	deal2 := NewDeal(amt1, amt2, msgs)
 

--- a/internal/dlc/execution_test.go
+++ b/internal/dlc/execution_test.go
@@ -17,15 +17,16 @@ func TestCotractExecutionTx(t *testing.T) {
 	// prepare a deal
 	var amt1, amt2 btcutil.Amount = 1, 1
 	msgs := [][]byte{[]byte{1}, []byte{1}}
-	deal := NewDeal(amt1, amt2, msgs)
+	deal1 := NewDeal(amt1, amt2, msgs)
+	deal2 := NewDeal(amt1, amt2, msgs)
 
-	dID := b1.AddDeal(deal)
-	_ = b2.AddDeal(deal)
+	dID := b1.AddDeal(deal1)
+	_ = b2.AddDeal(deal2)
 
 	// fail without oracle's message commitment
-	_, err := b1.SignContractExecutionTx(SecondParty, dID)
+	_, err := b1.SignContractExecutionTx(dID)
 	assert.NotNil(err)
-	_, err = b2.SignContractExecutionTx(FirstParty, dID)
+	_, err = b2.SignContractExecutionTx(dID)
 	assert.NotNil(err)
 
 	// oracle's message commitment/sign
@@ -44,9 +45,9 @@ func TestCotractExecutionTx(t *testing.T) {
 	assert.NotNil(err)
 
 	// exchange signs
-	sign1, err := b1.SignContractExecutionTx(SecondParty, dID)
+	sign1, err := b1.SignContractExecutionTx(dID)
 	assert.Nil(err)
-	sign2, err := b2.SignContractExecutionTx(FirstParty, dID)
+	sign2, err := b2.SignContractExecutionTx(dID)
 	assert.Nil(err)
 
 	err = b1.SetContextExecutionSign(dID, sign2)
@@ -54,6 +55,7 @@ func TestCotractExecutionTx(t *testing.T) {
 	err = b2.SetContextExecutionSign(dID, sign1)
 	assert.Nil(err)
 
+	// no errors with the counterparty's sign
 	tx1, err := b1.SignedContractExecutionTx(dID)
 	assert.Nil(err)
 	tx2, err := b2.SignedContractExecutionTx(dID)

--- a/internal/dlc/execution_test.go
+++ b/internal/dlc/execution_test.go
@@ -1,0 +1,97 @@
+package dlc
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+	"github.com/dgarage/dlc/internal/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCotractExecutionTx(t *testing.T) {
+	assert := assert.New(t)
+
+	b1, b2 := setupCountractors()
+
+	// prepare a deal
+	var amt1, amt2 btcutil.Amount = 1, 1
+	msgs := [][]byte{[]byte{1}, []byte{1}}
+	deal := NewDeal(amt1, amt2, msgs)
+
+	dID := b1.AddDeal(deal)
+	_ = b2.AddDeal(deal)
+
+	// fail without oracle's message commitment
+	_, err := b1.SignContractExecutionTx(SecondParty, dID)
+	assert.NotNil(err)
+	_, err = b2.SignContractExecutionTx(FirstParty, dID)
+	assert.NotNil(err)
+
+	// oracle's message commitment/sign
+	_, msgCommit := test.RandKeys()
+
+	// set message commitment
+	err = b1.SetMsgCommitmentToDeal(dID, msgCommit)
+	assert.Nil(err)
+	err = b2.SetMsgCommitmentToDeal(dID, msgCommit)
+	assert.Nil(err)
+
+	// fail without the counterparty's sign
+	_, err = b1.SignedContractExecutionTx(dID)
+	assert.NotNil(err)
+	_, err = b2.SignedContractExecutionTx(dID)
+	assert.NotNil(err)
+
+	// exchange signs
+	sign1, err := b1.SignContractExecutionTx(SecondParty, dID)
+	assert.Nil(err)
+	sign2, err := b2.SignContractExecutionTx(FirstParty, dID)
+	assert.Nil(err)
+
+	err = b1.SetContextExecutionSign(dID, sign2)
+	assert.Nil(err)
+	err = b2.SetContextExecutionSign(dID, sign1)
+	assert.Nil(err)
+
+	tx1, err := b1.SignedContractExecutionTx(dID)
+	assert.Nil(err)
+	tx2, err := b2.SignedContractExecutionTx(dID)
+	assert.Nil(err)
+	assert.NotEqual(tx1, tx2)
+
+	// run script
+	err = runFundScript(b1, tx1)
+	assert.Nil(err)
+	err = runFundScript(b2, tx2)
+	assert.Nil(err)
+}
+
+func setupCountractors() (b1, b2 *Builder) {
+	// init first party
+	w1 := setupTestWallet()
+	b1 = NewBuilder(FirstParty, mockSelectUnspent(w1, 1, 1, nil))
+	b1.SetFundAmounts(1, 1)
+	b1.PreparePubkey()
+	b1.PrepareFundTxIns()
+
+	// init second party
+	w2 := setupTestWallet()
+	b2 = NewBuilder(SecondParty, mockSelectUnspent(w2, 1, 1, nil))
+	b2.SetFundAmounts(1, 1)
+	b2.PreparePubkey()
+	b2.PrepareFundTxIns()
+
+	// exchange pubkeys
+	b1.CopyReqsFromCounterparty(b2.DLC())
+	b2.CopyReqsFromCounterparty(b1.DLC())
+
+	return b1, b2
+}
+
+func runFundScript(b *Builder, tx *wire.MsgTx) error {
+	d := b.DLC()
+	fundtx, _ := d.FundTx()
+	fout := fundtx.TxOut[fundTxOutAt]
+	return test.ExecuteScript(fout.PkScript, tx, fout.Value)
+}

--- a/internal/dlc/fundtx.go
+++ b/internal/dlc/fundtx.go
@@ -59,7 +59,7 @@ func (d *DLC) fundScript() ([]byte, error) {
 		return nil, errors.New("Second party must provide a pubkey for fund script")
 	}
 
-	return script.MultiSigScript2of2(pub1, pub2)
+	return script.FundScript(pub1, pub2)
 }
 
 // fundTxOutForRedeemTx creates a txout for the txin of redeem tx.
@@ -85,6 +85,24 @@ func (d *DLC) fundTxOutForRedeemTx() (*wire.TxOut, error) {
 	txout := wire.NewTxOut(int64(amt), pkScript)
 
 	return txout, nil
+}
+
+func (d *DLC) witnessForFundScript(
+	sign1, sign2 []byte) (wire.TxWitness, error) {
+
+	sc, err := d.fundScript()
+	if err != nil {
+		return nil, err
+	}
+
+	wit := script.WitnessForFundScript(sign1, sign2, sc)
+	return wit, nil
+}
+
+// SetFundAmounts sets fund amounts to DLC
+func (b *Builder) SetFundAmounts(amt1, amt2 btcutil.Amount) {
+	b.dlc.fundAmts[FirstParty] = amt1
+	b.dlc.fundAmts[SecondParty] = amt2
 }
 
 // fundAmount calculates total fund amount

--- a/internal/dlc/fundtx.go
+++ b/internal/dlc/fundtx.go
@@ -99,12 +99,6 @@ func (d *DLC) witnessForFundScript(
 	return wit, nil
 }
 
-// SetFundAmounts sets fund amounts to DLC
-func (b *Builder) SetFundAmounts(amt1, amt2 btcutil.Amount) {
-	b.dlc.fundAmts[FirstParty] = amt1
-	b.dlc.fundAmts[SecondParty] = amt2
-}
-
 // fundAmount calculates total fund amount
 func (d *DLC) fundAmount() (btcutil.Amount, error) {
 	amt1, ok := d.conds.FundAmts[FirstParty]

--- a/internal/dlc/refundtx.go
+++ b/internal/dlc/refundtx.go
@@ -96,6 +96,20 @@ func (d *DLC) witnessForRefundTx() (wire.TxWitness, error) {
 	return wt, nil
 }
 
+// AcceptRefundTxSign verifies couterparty's given sign is valid and then
+func (b *Builder) AcceptRefundTxSign(sign []byte) error {
+	p := counterparty(b.party)
+
+	err := b.dlc.VerifyRefundTx(sign, b.dlc.pubs[p])
+	if err != nil {
+		return fmt.Errorf("counterparty's signature didn't pass verification, had error: %v", err)
+	}
+
+	// sign passed verification, accept it
+	b.dlc.refundSigns[p] = sign
+	return nil
+}
+
 // VerifyRefundTx verifies the refund transaction signature.
 // Returns nil if the passed in sign is valid and corresponds to the passed
 // in public key, and an error if it isnt.

--- a/internal/dlc/refundtx_test.go
+++ b/internal/dlc/refundtx_test.go
@@ -35,8 +35,8 @@ func setupDLCRefund() (party1, party2 *Builder, d *DLC) {
 	rs2, _ := b2.SignRefundTx()
 
 	// exchange refund signs
-	b1.AcceptCounterpartySign(rs2)
-	b2.AcceptCounterpartySign(rs1)
+	b1.AcceptRefundTxSign(rs2)
+	b2.AcceptRefundTxSign(rs1)
 
 	d = b1.DLC()
 

--- a/internal/script/dlc.go
+++ b/internal/script/dlc.go
@@ -6,6 +6,9 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
+// ContractExecutionDelay is a delay used in ContractExecutionScript
+const ContractExecutionDelay = 144
+
 // ContractExecutionScript returns a contract execution script.
 //
 // Script Code:
@@ -29,7 +32,7 @@ func ContractExecutionScript(puba, pubb, pubm *btcec.PublicKey) ([]byte, error) 
 	pubam := &btcec.PublicKey{}
 	pubam.X, pubam.Y = btcec.S256().Add(puba.X, puba.Y, pubm.X, pubm.Y)
 
-	delay := uint16(144)
+	delay := uint16(ContractExecutionDelay)
 	csvflg := uint32(0x00000000)
 	builder := txscript.NewScriptBuilder()
 	builder.AddOp(txscript.OP_IF)

--- a/internal/script/dlc.go
+++ b/internal/script/dlc.go
@@ -1,0 +1,59 @@
+package script
+
+import (
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// ContractExecutionScript returns a contract execution script.
+//
+// Script Code:
+//  OP_IF
+//    <public key a + message public key>
+//  OP_ELSE
+//    delay(fix 144)
+//    OP_CHECKSEQUENCEVERIFY
+//    OP_DROP
+//    <public key b>
+//  OP_ENDIF
+//  OP_CHECKSIG
+//
+// The if block can be passed when the contractor A has a valid oracle's sign to the message.
+// But if the contractor sends this transaction without the oracle's valid sign, the else block will be used by the other party B after the delay time (1 day approximately).
+// Please check the original paper for more details.
+//
+// https://adiabat.github.io/dlc.pdf
+func ContractExecutionScript(puba, pubb, pubm *btcec.PublicKey) ([]byte, error) {
+	// pub key a + message pub key
+	pubam := &btcec.PublicKey{}
+	pubam.X, pubam.Y = btcec.S256().Add(puba.X, puba.Y, pubm.X, pubm.Y)
+
+	delay := uint16(144)
+	csvflg := uint32(0x00000000)
+	builder := txscript.NewScriptBuilder()
+	builder.AddOp(txscript.OP_IF)
+	builder.AddData(pubam.SerializeCompressed())
+	builder.AddOp(txscript.OP_ELSE)
+	builder.AddInt64(int64(delay) + int64(csvflg))
+	builder.AddOp(txscript.OP_CHECKSEQUENCEVERIFY)
+	builder.AddOp(txscript.OP_DROP)
+	builder.AddData(pubb.SerializeCompressed())
+	builder.AddOp(txscript.OP_ENDIF)
+	builder.AddOp(txscript.OP_CHECKSIG)
+	return builder.Script()
+}
+
+// WitnessForCEScript constracts a witness that unlocks a contract execution script.
+// This function use the OP_IF block
+func WitnessForCEScript(
+	sign []byte, script []byte) wire.TxWitness {
+	return wire.TxWitness{sign, []byte{1}, script}
+}
+
+// WitnessForCEScriptAfterDelay constracts a witness that unlocks a contract execution script.
+// This function use the OP_ELSE block that can be valid after the delay
+func WitnessForCEScriptAfterDelay(
+	sign []byte, script []byte) wire.TxWitness {
+	return wire.TxWitness{sign, []byte{}, script}
+}

--- a/internal/script/dlc.go
+++ b/internal/script/dlc.go
@@ -6,6 +6,29 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
+// FundScript is a 2-of-2 multisig script
+//
+// ScriptCode:
+//  OP_2
+//    <public key first party>
+//    <public key second party>
+//  OP_2
+//  OP_CHECKMULTISIG
+func FundScript(pub1, pub2 *btcec.PublicKey) (script []byte, err error) {
+	builder := txscript.NewScriptBuilder()
+	builder.AddOp(txscript.OP_2)
+	builder.AddData(pub1.SerializeCompressed())
+	builder.AddData(pub2.SerializeCompressed())
+	builder.AddOp(txscript.OP_2)
+	builder.AddOp(txscript.OP_CHECKMULTISIG)
+	return builder.Script()
+}
+
+// WitnessForFundScript constructs a witness for fund script
+func WitnessForFundScript(sign1, sign2, sc []byte) wire.TxWitness {
+	return wire.TxWitness{[]byte{}, sign1, sign2, sc}
+}
+
 // ContractExecutionDelay is a delay used in ContractExecutionScript
 const ContractExecutionDelay = 144
 

--- a/internal/script/dlc.go
+++ b/internal/script/dlc.go
@@ -23,7 +23,8 @@ const ContractExecutionDelay = 144
 //  OP_CHECKSIG
 //
 // The if block can be passed when the contractor A has a valid oracle's sign to the message.
-// But if the contractor sends this transaction without the oracle's valid sign, the else block will be used by the other party B after the delay time (1 day approximately).
+// But if the contractor sends this transaction without the oracle's valid sign,
+// the else block will be used by the other party B after the delay time (1 day approximately).
 // Please check the original paper for more details.
 //
 // https://adiabat.github.io/dlc.pdf
@@ -47,14 +48,14 @@ func ContractExecutionScript(puba, pubb, pubm *btcec.PublicKey) ([]byte, error) 
 	return builder.Script()
 }
 
-// WitnessForCEScript constracts a witness that unlocks a contract execution script.
+// WitnessForCEScript constructs a witness that unlocks a contract execution script.
 // This function use the OP_IF block
 func WitnessForCEScript(
 	sign []byte, script []byte) wire.TxWitness {
 	return wire.TxWitness{sign, []byte{1}, script}
 }
 
-// WitnessForCEScriptAfterDelay constracts a witness that unlocks a contract execution script.
+// WitnessForCEScriptAfterDelay constructs a witness that unlocks a contract execution script.
 // This function use the OP_ELSE block that can be valid after the delay
 func WitnessForCEScriptAfterDelay(
 	sign []byte, script []byte) wire.TxWitness {

--- a/internal/script/dlc_test.go
+++ b/internal/script/dlc_test.go
@@ -32,7 +32,7 @@ func TestCEScript(t *testing.T) {
 
 	// unlock with message sign
 	// TODO: should encapsulate this logic
-	n := utils.AddInts(priva.D, privm.D)
+	n := utils.AddBigInts(priva.D, privm.D)
 	privam, _ := btcec.PrivKeyFromBytes(btcec.S256(), n.Bytes())
 	signam, err := WitnessSignature(redeemTx, 0, amt, script, privam)
 	assert.Nil(err)

--- a/internal/script/dlc_test.go
+++ b/internal/script/dlc_test.go
@@ -1,0 +1,50 @@
+package script
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/dgarage/dlc/internal/test"
+	"github.com/dgarage/dlc/internal/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCEScript(t *testing.T) {
+	assert := assert.New(t)
+
+	priva, puba := test.RandKeys()
+	privb, pubb := test.RandKeys()
+	privm, pubm := test.RandKeys()
+	amt := int64(10000)
+
+	script, err := ContractExecutionScript(puba, pubb, pubm)
+	assert.Nil(err)
+	pkScript, err := P2WSHpkScript(script)
+	assert.Nil(err)
+
+	// prepare source tx
+	sourceTx := test.NewSourceTx()
+	sourceTx.AddTxOut(wire.NewTxOut(amt, pkScript))
+
+	// create redeem tx
+	redeemTx := test.NewRedeemTx(sourceTx, 0)
+
+	// unlock with message sign
+	// TODO: should encapsulate this logic
+	n := utils.AddInts(priva.D, privm.D)
+	privam, _ := btcec.PrivKeyFromBytes(btcec.S256(), n.Bytes())
+	signam, err := WitnessSignature(redeemTx, 0, amt, script, privam)
+	assert.Nil(err)
+	redeemTx.TxIn[0].Witness = WitnessForCEScript(signam, script)
+	err = test.ExecuteScript(pkScript, redeemTx, amt)
+	assert.Nil(err)
+
+	// unlock after delay
+	// redeemTx.TxIn[0].Sequence = 144
+	signb, err := WitnessSignature(redeemTx, 0, amt, script, privb)
+	assert.Nil(err)
+	redeemTx.TxIn[0].Witness = WitnessForCEScriptAfterDelay(signb, script)
+	err = test.ExecuteScript(pkScript, redeemTx, amt)
+	assert.Nil(err)
+}

--- a/internal/script/dlc_test.go
+++ b/internal/script/dlc_test.go
@@ -41,7 +41,7 @@ func TestCEScript(t *testing.T) {
 	assert.Nil(err)
 
 	// unlock after delay
-	// redeemTx.TxIn[0].Sequence = 144
+	redeemTx.TxIn[0].Sequence = ContractExecutionDelay
 	signb, err := WitnessSignature(redeemTx, 0, amt, script, privb)
 	assert.Nil(err)
 	redeemTx.TxIn[0].Witness = WitnessForCEScriptAfterDelay(signb, script)

--- a/internal/script/witness.go
+++ b/internal/script/witness.go
@@ -30,24 +30,6 @@ func P2WSHpkScript(script []byte) ([]byte, error) {
 	return builder.Script()
 }
 
-// MultiSigScript2of2 is a 2-of-2 multisig script
-//
-// ScriptCode:
-//  OP_2
-//    <public key first party>
-//    <public key second party>
-//  OP_2
-//  OP_CHECKMULTISIG
-func MultiSigScript2of2(pub1, pub2 *btcec.PublicKey) (script []byte, err error) {
-	builder := txscript.NewScriptBuilder()
-	builder.AddOp(txscript.OP_2)
-	builder.AddData(pub1.SerializeCompressed())
-	builder.AddData(pub2.SerializeCompressed())
-	builder.AddOp(txscript.OP_2)
-	builder.AddOp(txscript.OP_CHECKMULTISIG)
-	return builder.Script()
-}
-
 // WitnessSignature returns a witness signature for given script
 //
 // TODO: Note that txscript.RawTxInWitnessSignature converts a script from p2wkh to p2pkh implicitly.

--- a/internal/script/witness_test.go
+++ b/internal/script/witness_test.go
@@ -45,7 +45,7 @@ func TestMultiSigScript2of2(t *testing.T) {
 	priv2, pub2 := test.RandKeys()
 	amt := int64(10000)
 
-	script, err := MultiSigScript2of2(pub1, pub2)
+	script, err := FundScript(pub1, pub2)
 	assert.Nil(err)
 	pkScript, err := P2WSHpkScript(script)
 	assert.Nil(err)

--- a/internal/utils/bigint.go
+++ b/internal/utils/bigint.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"math/big"
+
+	"github.com/btcsuite/btcd/btcec"
+)
+
+// AddInts adds signs
+func AddInts(a, b *big.Int) *big.Int {
+	ab := new(big.Int).Add(a, b)
+	return new(big.Int).Mod(ab, btcec.S256().N)
+}

--- a/internal/utils/bigint.go
+++ b/internal/utils/bigint.go
@@ -6,8 +6,8 @@ import (
 	"github.com/btcsuite/btcd/btcec"
 )
 
-// AddInts adds signs
-func AddInts(a, b *big.Int) *big.Int {
+// AddBigInts adds signs
+func AddBigInts(a, b *big.Int) *big.Int {
 	ab := new(big.Int).Add(a, b)
 	return new(big.Int).Mod(ab, btcec.S256().N)
 }


### PR DESCRIPTION
ContractExecutionTxの作成の処理になります
- 相手のTxへのサイン
- 渡されたサインの検証
- 相手のサインと自分のサインを元にTxの作成

スコープ外
- ContractExecutionTxから取り出すTx

connect #33 
close #34